### PR TITLE
feature: option 'zoom with scroll wheel'

### DIFF
--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -10,7 +10,7 @@
     <gf-form-switch class="gf-form" label="Autozoom" label-class="width-11" tooltip="Automatically zoom the map to fit the data"
                     checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
     <gf-form-switch class="gf-form" label="Zoom with scroll wheel" label-class="width-11"
-                    checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.resetupMap()"/>
+                    checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.applyScrollZoom()"/>
   </div>
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -9,7 +9,7 @@
     </div>
     <gf-form-switch class="gf-form" label="Autozoom" label-class="width-11" tooltip="Automatically zoom the map to fit the data"
                     checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
-    <gf-form-switch class="gf-form" label="Zoom With Scroll Wheel" label-class="width-11"
+    <gf-form-switch class="gf-form" label="Zoom with scroll wheel" label-class="width-11"
                     checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.resetupMap()"/>
   </div>
   <div class="section gf-form-group">

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -7,6 +7,8 @@
         <input type="number" class="gf-form-input" ng-model="ctrl.panel.maxDataPoints" ng-change="ctrl.refresh()"/>
       </span>
     </div>
+    <gf-form-switch class="gf-form" label="Autozoom" label-class="width-11" tooltip="Automatically zoom the map to fit the data"
+      checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
     <gf-form-switch class="gf-form" label="Autozoom" label-class="width-9" tooltip="Automatically zoom the map to fit the data"
                     checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
   </div>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -8,9 +8,9 @@
       </span>
     </div>
     <gf-form-switch class="gf-form" label="Autozoom" label-class="width-11" tooltip="Automatically zoom the map to fit the data"
-      checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
-    <gf-form-switch class="gf-form" label="Autozoom" label-class="width-9" tooltip="Automatically zoom the map to fit the data"
                     checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
+    <gf-form-switch class="gf-form" label="Zoom With Scroll Wheel" label-class="width-11"
+                    checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.resetupMap()"/>
   </div>
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -10,6 +10,7 @@ import './partials/module.css!';
 const panelDefaults = {
   maxDataPoints: 500,
   autoZoom: true,
+  scrollWheelZoom: false,
   lineColor: 'red',
   pointColor: 'royalblue',
 }
@@ -142,6 +143,16 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     );
   }
 
+  resetupMap() {
+    if (this.polyline) {
+      this.polyline.removeFrom(this.leafMap);
+    }
+    this.onPanelClear();
+    this.leafMap.remove();
+    this.leafMap = null;
+    this.setupMap();
+  }
+
   setupMap() {
     log("setupMap");
     // Create the map or get it back in a clean state if it already exists
@@ -155,7 +166,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
 
     // Create the map
     this.leafMap = L.map('trackmap-' + this.panel.id, {
-      scrollWheelZoom: false,
+      scrollWheelZoom: this.panel.scrollWheelZoom,
       zoomSnap: 0.5,
       zoomDelta: 1,
     });

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -143,14 +143,16 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     );
   }
 
-  resetupMap() {
-    if (this.polyline) {
-      this.polyline.removeFrom(this.leafMap);
+  applyScrollZoom() {
+    let enabled = this.leafMap.scrollWheelZoom.enabled();
+    if (enabled != this.panel.scrollWheelZoom){
+      if (enabled){
+        this.leafMap.scrollWheelZoom.disable();
+      }
+      else{
+        this.leafMap.scrollWheelZoom.enable();
+      }
     }
-    this.onPanelClear();
-    this.leafMap.remove();
-    this.leafMap = null;
-    this.setupMap();
   }
 
   setupMap() {


### PR DESCRIPTION
One thing i like about Grafana is the ability to customize almost everything through options. This (really useful) plugin currently has a limited quantity of options, and i think adding more would constitute a significant improvement.

This PR allows the users to enable zooming with the scroll wheel, an hardcoded feature that can now be enabled or disabled at will.
The option is disabled by default.

![zsw](https://user-images.githubusercontent.com/46489434/55569343-b2ed7100-5701-11e9-837b-fca654283b36.png)

