### PR TITLE
Added option to show as points + show last point

### DIFF
--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -11,6 +11,8 @@
                     checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
     <gf-form-switch class="gf-form" label="Zoom with scroll wheel" label-class="width-11"
                     checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.applyScrollZoom()"/>
+    <gf-form-switch class="gf-form" label="Show as points" label-class="width-11"
+                    checked="ctrl.panel.showAsPoints" on-change="ctrl.changeViewType()"/>
     <div class="gf-form">
       <label class="gf-form-label width-9">Default layer</label>
       <div class="gf-form-select-wrapper max-width-11">
@@ -22,15 +24,21 @@
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>
     <div class="gf-form">
-      <label class="gf-form-label width-9">Line Color</label>
+      <label class="gf-form-label width-9">Line/Point Color</label>
       <span class="max-width-10">
         <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.lineColor" ng-change="ctrl.refreshColors()"/>
       </span>
     </div>
     <div class="gf-form">
-      <label class="gf-form-label width-9">Point Color</label>
+      <label class="gf-form-label width-9">Hover Point Color</label>
       <span class="max-width-10">
         <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.pointColor" ng-change="ctrl.refreshColors()"/>
+      </span>
+    </div>
+    <div class="gf-form">
+      <label class="gf-form-label width-9">Point Outline Color</label>
+      <span class="max-width-10">
+        <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.pointOutlineColor" ng-change="ctrl.refreshColors()"/>
       </span>
     </div>
   </div>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -33,5 +33,11 @@
         <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.pointColor" ng-change="ctrl.refreshColors()"/>
       </span>
     </div>
+    <div class="gf-form">
+      <label class="gf-form-label width-9">Last Point Color</label>
+      <span class="max-width-10">
+        <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.lastPointColor" ng-change="ctrl.refreshColors()"/>
+      </span>
+    </div>
   </div>
 </div>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -33,8 +33,13 @@
         <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.pointColor" ng-change="ctrl.refreshColors()"/>
       </span>
     </div>
+  </div>
+  <div class="section gf-form-group">
+    <h5 class="section-heading">Last point highlighting</h5>
+    <gf-form-switch class="gf-form" label="Enable" label-class="width-7"
+                    checked="ctrl.panel.enableLastPoint" on-change="ctrl.updateLastPoint()" />
     <div class="gf-form">
-      <label class="gf-form-label width-9">Last Point Color</label>
+      <label class="gf-form-label width-9">Point Color</label>
       <span class="max-width-10">
         <spectrum-picker class="gf-form-input" ng-model="ctrl.panel.lastPointColor" ng-change="ctrl.refreshColors()"/>
       </span>

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -1,5 +1,5 @@
 import L from './leaflet/leaflet.js';
-import moment, { relativeTimeThreshold } from 'moment';
+import moment from 'moment';
 
 import appEvents from 'app/core/app_events';
 import {MetricsPanelCtrl} from 'app/plugins/sdk';

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -14,6 +14,7 @@ const panelDefaults = {
   defaultLayer: 'OpenStreetMap',
   lineColor: 'red',
   pointColor: 'royalblue',
+  lastPointColor: 'lime',
 }
 
 function log(msg) {
@@ -54,6 +55,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.coords = [];
     this.leafMap = null;
     this.polyline = null;
+    this.lastPoint = null;
     this.hoverMarker = null;
     this.hoverTarget = null;
     this.setSizePromise = null;
@@ -197,6 +199,9 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       if (this.polyline) {
         this.polyline.removeFrom(this.leafMap);
       }
+      if (this.lastPoint) {
+        this.lastPoint.removeFrom(this.leafMap);
+      }
       this.onPanelClear();
       return;
     }
@@ -268,7 +273,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     }
   }
 
-  // Add the circles and polyline to the map
+  // Add the circles, polyline and last point to the map
   addDataToMap() {
     log("addDataToMap");
     this.polyline = L.polyline(
@@ -277,6 +282,14 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
         weight: 3,
       }
     ).addTo(this.leafMap);
+
+    this.lastPoint = L.circleMarker(this.coords[this.coords.length - 1].position, {
+      color: 'white',
+      fillColor: this.panel.lastPointColor,
+      fillOpacity: 1,
+      weight: 2,
+      radius: 7
+    }).addTo(this.leafMap);
 
     this.zoomToFit();
   }
@@ -296,7 +309,12 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
         color: this.panel.lineColor
       });
     }
-    if (this.hoverMarker){
+    if (this.lastPoint) {
+      this.lastPoint.setStyle({
+        fillColor: this.panel.lastPointColor,
+      });
+    }
+    if (this.hoverMarker) {
       this.hoverMarker.setStyle({
         fillColor: this.panel.pointColor,
       });

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -14,6 +14,7 @@ const panelDefaults = {
   defaultLayer: 'OpenStreetMap',
   lineColor: 'red',
   pointColor: 'royalblue',
+  enableLastPoint: true,
   lastPointColor: 'lime',
 }
 
@@ -283,18 +284,27 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       }
     ).addTo(this.leafMap);
 
-    this.lastPoint = L.circleMarker(this.coords[this.coords.length - 1].position, {
-      color: 'white',
-      fillColor: this.panel.lastPointColor,
-      fillOpacity: 1,
-      weight: 2,
-      radius: 7
-    }).addTo(this.leafMap);
+    this.updateLastPoint();
 
     this.zoomToFit();
   }
 
-  zoomToFit(){
+  updateLastPoint() {
+    if (this.panel.enableLastPoint) {
+      this.lastPoint = L.circleMarker(this.coords[this.coords.length - 1].position, {
+        color: 'white',
+        fillColor: this.panel.lastPointColor,
+        fillOpacity: 1,
+        weight: 2,
+        radius: 7,
+      }).addTo(this.leafMap);
+    } else if (this.lastPoint != null) {
+      this.lastPoint.removeFrom(this.leafMap);
+      this.lastPoint = null;
+    }
+  }
+
+  zoomToFit() {
     log("zoomToFit");
     if (this.panel.autoZoom && this.polyline){
       this.leafMap.fitBounds(this.polyline.getBounds());


### PR DESCRIPTION
1. I have added ability to show data as points, where they change opacity based on recency of data (older points have less opacity). May fix #6 and fix #11.
2. Also added possibility to turn on additional point for last data entry (also works for line) to simulate last/current location.

Options look now like this:
![image](https://user-images.githubusercontent.com/24546950/83978923-6a3bd400-a913-11ea-92ce-721289545fde.png)
Due to privacy reasons, I have not added a screenshot of the visuals in map.