### PR TITLE
Adding Eniro Seamap

### DIFF
--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -1,6 +1,6 @@
 <div class="editor-row">
   <div class="section gf-form-group">
-    <h5 class="section-heading">Options</h5>
+    <h5 class="section-heading">Panel Options</h5>
     <div class="gf-form">
       <label class="gf-form-label width-9">Max data points</label>
       <span class="max-width-10">
@@ -8,9 +8,9 @@
       </span>
     </div>
     <gf-form-switch class="gf-form" label="Autozoom" label-class="width-11" tooltip="Automatically zoom the map to fit the data?"
-                    checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"/>
+                    checked="ctrl.panel.autoZoom" on-change="ctrl.zoomToFit()"></gf-form-switch>
     <gf-form-switch class="gf-form" label="Zoom with scroll wheel" label-class="width-11"
-                    checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.applyScrollZoom()"/>
+                    checked="ctrl.panel.scrollWheelZoom" on-change="ctrl.applyScrollZoom()"></gf-form-switch>
     <div class="gf-form">
       <label class="gf-form-label width-9">Default map style</label>
       <div class="gf-form-select-wrapper max-width-11">
@@ -19,7 +19,7 @@
       </div>
     </div>
     <gf-form-switch class="gf-form" label="Show layer changer" label-class="width-11" tooltip="Allow viewers to change the map style?"
-                    checked="ctrl.panel.showLayerChanger" on-change="ctrl.applyDefaultLayer()"/>
+                    checked="ctrl.panel.showLayerChanger" on-change="ctrl.applyDefaultLayer()"></gf-form-switch>
   </div>
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -64,6 +64,12 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
           subdomains: 'abcd',
           maxZoom: 20,
         })
+      }),
+      'Eniro Seamap': L.tileLayer('https://{s}.eniro.com/geowebcache/service/tms1.0.0/nautical/{z}/{x}/{y}.png', {
+        subdomains: ['map01', 'map02', 'map03', 'map04'],
+        attribution: '&copy; Kort & Matrikelstyrelsen',
+        tms: true,
+        maxZoom: 17,
       })
     };
 


### PR DESCRIPTION
Adding Eniro Seamap (for Scandinavia)

Also changed:

`<gf-form-switch />` to `<gf-form-switch></gf-form-switch>` in partials/options.html

In order to have all options be displayed