### PR TITLE
Fix multiple maps not rendering

### DIFF
--- a/src/TrackMapPanel.tsx
+++ b/src/TrackMapPanel.tsx
@@ -8,7 +8,7 @@ import {
   PanelData,
 } from '@grafana/data';
 import { Subscription } from 'rxjs';
-import { CircleMarker, Control, LatLng, Map as LeafMap, LeafletEventHandlerFn, Polyline, TileLayer } from 'leaflet';
+import { CircleMarker, Control, LatLng, Map as LeafMap, LeafletEventHandlerFn, Polyline, TileLayer, LayerGroup } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 import {
@@ -19,7 +19,7 @@ import {
   TrackMapProps,
   setDashboardTimeRangeFunction,
 } from './types';
-import { LAYERS } from './layers';
+import { getLayers } from './layers';
 
 function log(...args: any) {
   // uncomment for debugging
@@ -73,6 +73,7 @@ class TrackMapState {
   lineColor: string | undefined;
   autoZoom: boolean;
   setDashboardTimeRange: setDashboardTimeRangeFunction;
+  layers: { [key: string]: TileLayer | LayerGroup };
 
   constructor(containerId: string, setDashboardTimeRange: setDashboardTimeRangeFunction) {
     log('panelInit', containerId);
@@ -92,8 +93,9 @@ class TrackMapState {
     });
     this.hoverTarget = null;
 
+    this.layers = getLayers();
     // Create the layer changer
-    this.layerChanger = new Control.Layers(LAYERS);
+    this.layerChanger = new Control.Layers(this.layers);
 
     // Create the map and set up events
     this.leafMap = new LeafMap(containerId, {
@@ -220,7 +222,8 @@ class TrackMapState {
         })
       );
     } else {
-      this.leafMap.addLayer(LAYERS[layerName]);
+      // Use the cloned layers instead of the global LAYERS object
+      this.leafMap.addLayer(this.layers[layerName]);
     }
 
     this.addLinesToMap();

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,42 +1,46 @@
 import { LayerGroup, TileLayer } from 'leaflet';
 
+export const LAYER_NAMES = ['OpenStreetMap', 'CyclOSM', 'OpenTopoMap', 'Satellite', 'OpenSeaMap'];
+
 // Save layers globally in order to use them in options
-export const LAYERS: { [key: string]: TileLayer | LayerGroup } = {
-  OpenStreetMap: new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    maxNativeZoom: 19,
-  }),
-  CyclOSM: new TileLayer('https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png', {
-    attribution:
-      'Map data: &copy; <a href="/copyright">OpenStreetMap contributors</a>. Tiles style by <a href="https://www.cyclosm.org">CyclOSM</a> hosted by <a href="https://openstreetmap.fr/">OpenStreetMap France</a>',
-    maxNativeZoom: 20,
-  }),
-  OpenTopoMap: new TileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-    attribution:
-      'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
-    maxNativeZoom: 17,
-  }),
-  Satellite: new LayerGroup([
-    new TileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-      attribution: 'Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community',
-      maxNativeZoom: 23,
-    }),
-    new TileLayer(
-      'https://server.arcgisonline.com/arcgis/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
-      {
-        attribution: 'Esri, HERE, Garmin, (c) OpenStreetMap contributors, and the GIS user community',
-        maxNativeZoom: 23,
-      }
-    ),
-  ]),
-  OpenSeaMap: new LayerGroup([
-    new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+export const getLayers = (): { [key: string]: TileLayer | LayerGroup } => {
+  return {
+    OpenStreetMap: new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       maxNativeZoom: 19,
     }),
-    new TileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
-      attribution: 'Sea marks from <a href="https://map.openseamap.org">OpenSeaMap</a>',
-      maxNativeZoom: 18,
+    CyclOSM: new TileLayer('https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png', {
+      attribution:
+        'Map data: &copy; <a href="/copyright">OpenStreetMap contributors</a>. Tiles style by <a href="https://www.cyclosm.org">CyclOSM</a> hosted by <a href="https://openstreetmap.fr/">OpenStreetMap France</a>',
+      maxNativeZoom: 20,
     }),
-  ]),
+    OpenTopoMap: new TileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+      attribution:
+        'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+      maxNativeZoom: 17,
+    }),
+    Satellite: new LayerGroup([
+      new TileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community',
+        maxNativeZoom: 23,
+      }),
+      new TileLayer(
+        'https://server.arcgisonline.com/arcgis/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
+        {
+          attribution: 'Esri, HERE, Garmin, (c) OpenStreetMap contributors, and the GIS user community',
+          maxNativeZoom: 23,
+        }
+      ),
+    ]),
+    OpenSeaMap: new LayerGroup([
+      new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        maxNativeZoom: 19,
+      }),
+      new TileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
+        attribution: 'Sea marks from <a href="https://map.openseamap.org">OpenSeaMap</a>',
+        maxNativeZoom: 18,
+      }),
+    ]),
+  };
 };

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { PanelPlugin } from '@grafana/data';
 import { TrackMapOptions } from './types';
 import { TrackMapPanel } from './TrackMapPanel';
-import { LAYERS } from './layers';
+import { LAYER_NAMES } from './layers';
 
 export const plugin = new PanelPlugin<TrackMapOptions>(TrackMapPanel).setPanelOptions((builder) => {
   return builder
@@ -23,7 +23,7 @@ export const plugin = new PanelPlugin<TrackMapOptions>(TrackMapPanel).setPanelOp
       description: 'The map style to use by default',
       defaultValue: 'OpenStreetMap',
       settings: {
-        options: Object.keys(LAYERS).map((k) => ({ value: k, label: k })),
+        options: LAYER_NAMES.map((k) => ({ value: k, label: k })),
       },
     })
     .addBooleanSwitch({


### PR DESCRIPTION
## This PR aims to fix #89 

### **Changes:**
- **Refactor `LAYERS`:** 
  - Replaced the global `LAYERS` object with a `getLayers()` function that returns a new instance of map layers each time it is called.
  - This ensures that every map has its own set of layer objects to prevent tile loading conflicts caused by shared state.

- **Exported `LAYER_NAMES`:**
  - Refactored how the map layer names are used in the `PanelPlugin` options to ensure compatibility.
  - The `LAYER_NAMES` array was introduced to maintain the list of available layer names separately from the actual layer objects.

- **Updated TrackMapPanel:**
  - Modified `TrackMapPanel.tsx` to use the `getLayers()` function, ensuring each map receives its own set of layers, solving the issue of race conditions in tile rendering.

### **Files Modified:**
- `src/TrackMapPanel.tsx`
- `src/layers.ts`
- `src/module.ts`

### **Steps to Reproduce (Before the fix):**
1. Use the plugin in more than one panel in a dashboard. 
2. Observe that only the one of the panels map will load when all the panels have the same default map (If maps have different default maps the issue doesn't occur). 
